### PR TITLE
fix(imports): update endpoint imports to use .js extension

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@ import type { CollectionConfig, Config, Plugin } from 'payload'
 
 import { cookies } from 'next/headers.js'
 
-import { masqueradeEndpoint } from './endpoints/masqueradeEndpoint.ts'
-import { unmasqueradeEndpoint } from './endpoints/unmasqueradeEndpoint.ts'
+import { masqueradeEndpoint } from './endpoints/masqueradeEndpoint.js'
+import { unmasqueradeEndpoint } from './endpoints/unmasqueradeEndpoint.js'
 
 export interface PluginTypes {
   /**


### PR DESCRIPTION
Changed the import statements for masqueradeEndpoint and unmasqueradeEndpoint to use the .js extension instead of .ts. This ensures compatibility with environments expecting JavaScript file extensions, such as Next.js or bundlers that do not resolve .ts extensions at runtime.